### PR TITLE
Add SafeMode option to test settings for Excel launch

### DIFF
--- a/ExcelDna.Testing/Examples/InProcessTests.cs
+++ b/ExcelDna.Testing/Examples/InProcessTests.cs
@@ -63,7 +63,7 @@ namespace Examples
             Assert.Equal("Completed", targetRange.Value);
         }
 
-        [ExcelFact(Workbook = "", AddIn = @"..\..\..\..\ExampleAddinNET6\bin\Debug\net6.0-windows\ExampleAddinNET6-AddIn")]
+        [ExcelFact(Workbook = "", AddIn = @"..\..\..\..\ExampleAddinNET6\bin\Debug\net6.0-windows\ExampleAddinNET6-AddIn", SafeMode = true)]
         public void FunctionTestNET6()
         {
             Range targetRange = (ExcelDna.Testing.Util.Workbook.Sheets[1] as Worksheet).Range["A1"];

--- a/ExcelDna.Testing/ExcelDna.Testing/ExcelFactAttribute.cs
+++ b/ExcelDna.Testing/ExcelDna.Testing/ExcelFactAttribute.cs
@@ -16,5 +16,8 @@ namespace Xunit
 
         /// <inheritdoc />
         public string AddIn { get; set; }
+
+        /// <inheritdoc />
+        public bool SafeMode { get; set; }
     }
 }

--- a/ExcelDna.Testing/ExcelDna.Testing/ExcelFactDiscoverer.cs
+++ b/ExcelDna.Testing/ExcelDna.Testing/ExcelFactDiscoverer.cs
@@ -24,7 +24,8 @@ namespace ExcelDna.Testing
             return new ExcelTestSettings(
                 GetSetting<bool>(testMethod, nameof(ExcelFactAttribute.OutOfProcess)),
                 GetSetting<string>(testMethod, nameof(ExcelFactAttribute.Workbook)),
-                GetSetting<string>(testMethod, nameof(ExcelFactAttribute.AddIn)));
+                GetSetting<string>(testMethod, nameof(ExcelFactAttribute.AddIn)),
+                GetSetting<bool>(testMethod, nameof(ExcelFactAttribute.SafeMode)));
         }
 
         private static T GetSetting<T>(ITestMethod testMethod, string name)

--- a/ExcelDna.Testing/ExcelDna.Testing/ExcelRunner.cs
+++ b/ExcelDna.Testing/ExcelDna.Testing/ExcelRunner.cs
@@ -13,13 +13,19 @@ namespace ExcelDna.Testing
             excelDetected = excelDetector.TryFindLatestExcel(out excelExePath) && excelDetector.TryFindExcelBitness(excelExePath, out bitness);
         }
 
-        public Process Start(string addinAssemblyPath, IEnumerable<string> addins)
+        public Process Start(string addinAssemblyPath, IEnumerable<string> addins, bool safeMode = false)
         {
             if (!excelDetected)
                 throw new ApplicationException("Can't find an installed version of Excel.");
 
             string addinAssemblyDirectory = Path.GetDirectoryName(addinAssemblyPath);
             string arguments = "";
+            
+            if (safeMode)
+            {
+                arguments += "/safe ";
+            }
+            
             foreach (string externalAddinRelativePath in addins)
             {
                 arguments += Quote(GetXllPath(addinAssemblyDirectory, externalAddinRelativePath, bitness)) + " ";

--- a/ExcelDna.Testing/ExcelDna.Testing/ExcelTestAssemblyRunner.cs
+++ b/ExcelDna.Testing/ExcelDna.Testing/ExcelTestAssemblyRunner.cs
@@ -35,14 +35,17 @@ namespace ExcelDna.Testing
         protected override async Task<RunSummary> RunTestCollectionsAsync(IMessageBus messageBus, CancellationTokenSource cancellationTokenSource)
         {
             IEnumerable<IXunitTestCase> localTestCases = TestCases.Except(TestCases.OfType<ExcelTestCase>());
-            IEnumerable<ExcelTestCase> excelInProcessTestCases = TestCases.OfType<ExcelTestCase>().Where(i => !i.Settings.OutOfProcess);
+            IEnumerable<ExcelTestCase> excelInProcessTestCases = TestCases.OfType<ExcelTestCase>().Where(i => !i.Settings.OutOfProcess && !i.Settings.SafeMode);
+            IEnumerable<ExcelTestCase> excelInProcessSafeTestCases = TestCases.OfType<ExcelTestCase>().Where(i => !i.Settings.OutOfProcess && i.Settings.SafeMode);
             IEnumerable<ExcelTestCase> excelOutOfProcessTestCases = TestCases.OfType<ExcelTestCase>().Where(i => i.Settings.OutOfProcess);
 
             var result = await LocalRunTestCasesAsync(localTestCases, messageBus, cancellationTokenSource);
             if (excelOutOfProcessTestCases.Count() > 0)
                 result.Aggregate(await COMRunTestCasesAsync(excelOutOfProcessTestCases, messageBus, cancellationTokenSource));
             if (excelInProcessTestCases.Count() > 0)
-                result.Aggregate(await RemoteRunTestCasesAsync(excelInProcessTestCases, messageBus, cancellationTokenSource));
+                result.Aggregate(await RemoteRunTestCasesAsync(excelInProcessTestCases, messageBus, cancellationTokenSource, false));
+            if (excelInProcessSafeTestCases.Count() > 0)
+                result.Aggregate(await RemoteRunTestCasesAsync(excelInProcessSafeTestCases, messageBus, cancellationTokenSource, true));
 
             CleanupReferences();
 
@@ -58,13 +61,13 @@ namespace ExcelDna.Testing
             return result;
         }
 
-        private async Task<RunSummary> RemoteRunTestCasesAsync(IEnumerable<ExcelTestCase> testCases, IMessageBus messageBus, CancellationTokenSource cancellationTokenSource)
+        private async Task<RunSummary> RemoteRunTestCasesAsync(IEnumerable<ExcelTestCase> testCases, IMessageBus messageBus, CancellationTokenSource cancellationTokenSource, bool safeMode)
         {
             RunSummary result = new RunSummary();
             try
             {
                 ExcelStartupEvent.Create();
-                Process excelProcess = excelRunner.Start(testAssembly.Assembly.AssemblyPath, GetAddins(testCases));
+                Process excelProcess = excelRunner.Start(testAssembly.Assembly.AssemblyPath, GetAddins(testCases), safeMode);
                 if (!ExcelStartupEvent.Wait(30000))
                     throw new System.ApplicationException("Excel startup failed.");
 

--- a/ExcelDna.Testing/ExcelDna.Testing/ExcelTestCase.cs
+++ b/ExcelDna.Testing/ExcelDna.Testing/ExcelTestCase.cs
@@ -35,6 +35,7 @@ namespace ExcelDna.Testing
             info.AddValue(nameof(testSettings.OutOfProcess), testSettings.OutOfProcess);
             info.AddValue(nameof(testSettings.Workbook), testSettings.Workbook);
             info.AddValue(nameof(testSettings.AddIn), testSettings.AddIn);
+            info.AddValue(nameof(testSettings.SafeMode), testSettings.SafeMode);
         }
 
         public override void Deserialize(IXunitSerializationInfo info)
@@ -43,7 +44,8 @@ namespace ExcelDna.Testing
             testSettings = new ExcelTestSettings(
                 info.GetValue<bool>(nameof(testSettings.OutOfProcess)),
                 info.GetValue<string>(nameof(testSettings.Workbook)),
-                info.GetValue<string>(nameof(testSettings.AddIn)));
+                info.GetValue<string>(nameof(testSettings.AddIn)),
+                info.GetValue<bool>(nameof(testSettings.SafeMode)));
         }
 
         public string SerializeToString()

--- a/ExcelDna.Testing/ExcelDna.Testing/ExcelTestSettings.cs
+++ b/ExcelDna.Testing/ExcelDna.Testing/ExcelTestSettings.cs
@@ -2,11 +2,12 @@
 {
     public class ExcelTestSettings : ITestSettings
     {
-        public ExcelTestSettings(bool outOfProcess, string workbook, string addin)
+        public ExcelTestSettings(bool outOfProcess, string workbook, string addin, bool safeMode = false)
         {
             OutOfProcess = outOfProcess;
             Workbook = workbook;
             AddIn = addin;
+            SafeMode = safeMode;
         }
 
         public bool OutOfProcess { get; set; }
@@ -14,5 +15,7 @@
         public string Workbook { get; set; }
 
         public string AddIn { get; set; }
+
+        public bool SafeMode { get; set; }
     }
 }

--- a/ExcelDna.Testing/ExcelDna.Testing/ExcelTestSettingsAttribute.cs
+++ b/ExcelDna.Testing/ExcelDna.Testing/ExcelTestSettingsAttribute.cs
@@ -14,5 +14,8 @@ namespace Xunit
 
         /// <inheritdoc />
         public string AddIn { get; set; }
+
+        /// <inheritdoc />
+        public bool SafeMode { get; set; }
     }
 }

--- a/ExcelDna.Testing/ExcelDna.Testing/ITestSettings.cs
+++ b/ExcelDna.Testing/ExcelDna.Testing/ITestSettings.cs
@@ -16,5 +16,10 @@
         /// A relative path to .xll add-in to load. Without bitness and .xll extension.
         /// </summary>
         string AddIn { get; set; }
+
+        /// <summary>
+        /// Whether to start Excel in safe mode using the /safe command-line switch.
+        /// </summary>
+        bool SafeMode { get; set; }
     }
 }


### PR DESCRIPTION
Introduce SafeMode property to ExcelFactAttribute, ExcelTestSettingsAttribute, allowing tests to specify launching Excel in safe mode (/safe).  This basically allows to run tests in working area that avoids conflicts with other addins.